### PR TITLE
Verify Xdebug 2.6 availability to avoid issues

### DIFF
--- a/Dockerfile-cli-dev
+++ b/Dockerfile-cli-dev
@@ -1,8 +1,12 @@
 FROM usabillabv/php-base:cli
 
-RUN apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+# Avoid xdebug installation if we don't have xdebug 2.6.0 (check can be removed after xdebug release)
+RUN export XDEBUG_AVAILABLE=`pecl remote-info xdebug | grep 2.6.0 | wc -l | xargs` \
+    && if [ "$XDEBUG_AVAILABLE" == "1" ]; then \
+    apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug \
-    && apk del .phpize-deps
+    && apk del .phpize-deps \
+    ;fi
 
 COPY common/php/conf/debug.ini /usr/local/etc/php/conf.d/zzz_debug.ini

--- a/Dockerfile-http-dev
+++ b/Dockerfile-http-dev
@@ -4,9 +4,13 @@ ENV NGINX_EXPOSE_VERSION=on
 
 EXPOSE 9000
 
-RUN apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+# Avoid xdebug installation if we don't have xdebug 2.6.0 (check can be removed after xdebug release)
+RUN export XDEBUG_AVAILABLE=`pecl remote-info xdebug | grep 2.6.0 | wc -l | xargs` \
+    && if [ "$XDEBUG_AVAILABLE" == "1" ]; then \
+    apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug \
-    && apk del .phpize-deps
+    && apk del .phpize-deps \
+    ;fi
 
 COPY common/php/conf/debug.ini /usr/local/etc/php/conf.d/zzz_debug.ini


### PR DESCRIPTION
Since we don't have it available yet the container fails to build and according to the maintainers it will take some time to have it. There is a list of issues to be fixed and they also want to solve windows compatibility bugs.

More info: https://bugs.xdebug.org/roadmap_page.php?version_id=43