### PR TITLE
[OZ-583] Enable PHP pcntl support

### DIFF
--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -20,7 +20,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHPIZE_DEPS autoconf dpkg-dev dpkg file g++ gcc libc-dev make pcre-dev pkgconf re2c
 ENV PHP_INI_DIR /usr/local/etc/php
-ENV PHP_EXTRA_CONFIGURE_ARGS --disable-cgi
+ENV PHP_EXTRA_CONFIGURE_ARGS --disable-cgi --enable-pcntl
 ENV PHP_VERSION 7.2.0
 ENV PHP_SHA256="87572a6b924670a5d4aac276aaa4a94321936283df391d702c845ffc112db095"
 ENV PHP_URL="https://secure.php.net/get/php-$PHP_VERSION.tar.xz/from/this/mirror"


### PR DESCRIPTION
Reviewers: @rdohms @lcobucci 
Contributes to: OZ-583

This way we can catch Ctrl-C on the CLI and graciously stop consumers, flush buffers, etc