### PR TITLE
Tweak assertion configuration

### DIFF
--- a/common/php/conf/debug.ini
+++ b/common/php/conf/debug.ini
@@ -7,3 +7,5 @@ xdebug.remote_enable=1
 xdebug.remote_host=docker.for.mac.localhost
 xdebug.remote_connect_back=0
 xdebug.profiler_enable_trigger=1
+
+zend.assertions=1

--- a/common/php/conf/default.ini
+++ b/common/php/conf/default.ini
@@ -6,3 +6,6 @@ opcache.validate_timestamps=0
 opcache.enable_file_override=1
 
 expose_php=off
+
+zend.assertions=-1
+assert.exception=1


### PR DESCRIPTION
To avoid generation of unnecessary items on the AST and ensure that we have exceptions when assertions fail.