### PR TITLE
Use LibreSSL instead of OpenSSL

### DIFF
--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -44,7 +44,7 @@ COPY common/gnupg/fetch-keys.sh /usr/src/
 # </copy installation>
 
 # <download packages>
-RUN apk add --no-cache --virtual .fetch-deps gnupg openssl \
+RUN apk add --no-cache --virtual .fetch-deps gnupg libressl \
     && export GNUPGHOME="$(mktemp -d)" \
     && /usr/src/fetch-keys.sh \
     && /root/php-install/download.sh \
@@ -65,7 +65,7 @@ RUN apk add --no-cache --virtual .build-deps $PHPIZE_DEPS \
     libxml2-dev \
     libxslt-dev \
     linux-headers \
-    openssl-dev \
+    libressl-dev \
     sqlite-dev \
     zlib-dev \
     && /root/php-install/compile.sh \

--- a/Dockerfile-http
+++ b/Dockerfile-http
@@ -56,7 +56,7 @@ COPY common/gnupg/fetch-keys.sh /usr/src/
 # </copy installation>
 
 # <download packages>
-RUN apk add --no-cache --virtual .fetch-deps gnupg openssl \
+RUN apk add --no-cache --virtual .fetch-deps gnupg libressl \
     && export GNUPGHOME="$(mktemp -d)" \
     && /usr/src/fetch-keys.sh \
     && /root/php-install/download.sh \
@@ -80,7 +80,7 @@ RUN apk add --no-cache --virtual .build-deps $PHPIZE_DEPS \
     libxml2-dev \
     libxslt-dev \
     linux-headers \
-    openssl-dev \
+    libressl-dev \
     sqlite-dev \
     zlib-dev \
     && /root/php-install/compile.sh \


### PR DESCRIPTION
Alpine has moved from OpenSSL to LibreSSL, see also
https://lists.alpinelinux.org/alpine-devel/5463.html. Because of that,
PHP crashes when connecting to a url starting with https://.