### PR TITLE
Update docker-compose on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,11 @@ jobs:
       - checkout
       - attach_workspace:
           at: ./tmp
+      - run:
+          name: Update Docker Compose
+          command: |
+            sudo curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+            sudo chmod +x /usr/local/bin/docker-compose
       - run: docker load -i ./tmp/usabillabv_php-http.tar
       - run: docker load -i ./tmp/usabillabv_php-fpm.tar
       - run: make ci-test

--- a/Makefile
+++ b/Makefile
@@ -60,28 +60,28 @@ test:
 	docker-compose -p php-docker-template-tests up --force-recreate --build -d \
 		|| (docker-compose -p php-docker-template-tests down; echo "tests failed" && exit 1)
 	docker run --rm -t \
-		--network phpdockertemplatetests_backend-php \
+		--network php-docker-template-tests_backend-php \
 		-v "${current_dir}/test:/tests" \
 		-v /var/run/docker.sock:/var/run/docker.sock:ro \
-		renatomefi/docker-testinfra:latest --verbose --hosts='docker://phpdockertemplatetests_php_fpm_1' -m php \
+		renatomefi/docker-testinfra:latest --verbose --hosts='docker://php-docker-template-tests_php_fpm_1' -m php \
 		|| (docker-compose -p php-docker-template-tests down; echo "tests failed" && exit 1)
 	docker run --rm -t \
-		--network phpdockertemplatetests_backend-php \
+		--network php-docker-template-tests_backend-php \
 		-v "${current_dir}/test:/tests" \
 		-v /var/run/docker.sock:/var/run/docker.sock:ro \
-		renatomefi/docker-testinfra:latest --verbose --hosts='docker://phpdockertemplatetests_nginx_1' -m nginx	 \
+		renatomefi/docker-testinfra:latest --verbose --hosts='docker://php-docker-template-tests_nginx_1' -m nginx	 \
 		|| (docker-compose -p php-docker-template-tests down; echo "tests failed" && exit 1)
 	docker-compose -p php-docker-template-tests down
 
 ci-test:
-	docker-compose -p php-docker-template-tests up -d
+	docker-compose -p php-docker-template-tests up --force-recreate -d
 	docker run --rm -t \
-		--network phpdockertemplatetests_backend-php \
+		--network php-docker-template-tests_backend-php \
 		-v "${current_dir}/test:/tests" \
 		-v /var/run/docker.sock:/var/run/docker.sock:ro \
-		renatomefi/docker-testinfra:latest --verbose --hosts='docker://phpdockertemplatetests_php_fpm_1' -m php --junitxml=/tests/test-results/php.xml
+		renatomefi/docker-testinfra:latest --verbose --hosts='docker://php-docker-template-tests_php_fpm_1' -m php --junitxml=/tests/test-results/php.xml
 	docker run --rm -t \
-		--network phpdockertemplatetests_backend-php \
+		--network php-docker-template-tests_backend-php \
 		-v "${current_dir}/test:/tests" \
 		-v /var/run/docker.sock:/var/run/docker.sock:ro \
-		renatomefi/docker-testinfra:latest --verbose --hosts='docker://phpdockertemplatetests_nginx_1' -m nginx --junitxml=/tests/test-results/nginx.xml
+		renatomefi/docker-testinfra:latest --verbose --hosts='docker://php-docker-template-tests_nginx_1' -m nginx --junitxml=/tests/test-results/nginx.xml


### PR DESCRIPTION
The current docker-compose version on CircleCI is 1.17.0, which is behind mostly developers machines, being 1.21 and 1.22. The case is during 1.21 a breaking change was introduced:
"Dashes and underscores in project names are no longer stripped out." at https://github.com/docker/compose/releases/tag/1.21.0
This causes networks names and container names different than expected Makefile has been updated with the new names now