### PR TITLE
Let Nginx forward all calls to php-fpm

### DIFF
--- a/src/http/nginx/conf/vhost.conf.template
+++ b/src/http/nginx/conf/vhost.conf.template
@@ -3,22 +3,16 @@ server {
     listen [::]:80;
     server_name  ${NGINX_SERVER_NAME};
 
-    root   ${NGINX_DOCUMENT_ROOT};
-    index  index.php index.html index.htm;
+    root    ${NGINX_DOCUMENT_ROOT};
     charset UTF-8;
-
-    location / {
-        try_files ${ESCAPE}uri /index.php${ESCAPE}is_args${ESCAPE}args;
-    }
 
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
         root   /usr/share/nginx/html;
     }
-
-    location = /favicon.ico {
-        log_not_found off;
-        access_log off;
+    
+    location / {
+        rewrite ^ /index.php last;
     }
 
     location ~ \.php$ {
@@ -27,7 +21,7 @@ server {
 
         include        fastcgi_params;
 
-        fastcgi_param SCRIPT_FILENAME ${ESCAPE}realpath_root${ESCAPE}fastcgi_script_name;
-        fastcgi_param DOCUMENT_ROOT ${ESCAPE}realpath_root;
+        fastcgi_param SCRIPT_FILENAME ${ESCAPE}document_root${ESCAPE}fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT ${ESCAPE}document_root;
     }
 }

--- a/test/container/test_user.py
+++ b/test/container/test_user.py
@@ -20,7 +20,7 @@ def test_fpm_can_create_file(host):
   host.run("rm {0}".format(testFile))
 
   assert host.file(testFile).exists is False
-  host.run("wget http://nginx/filesystem.php")
+  host.run("wget -O /dev/null http://nginx?testFile=true")
   assert host.file(testFile).exists is True
   assert host.file(testFile).user == "app"
   assert host.file(testFile).group == "app"

--- a/test/filesystem.php
+++ b/test/filesystem.php
@@ -1,8 +1,0 @@
-<?php
-
-echo '<h2>whoami? ' . shell_exec('whoami') . '</h2>';
-
-$file = new \SplFileObject('/tmp/temptestfile', "w");
-$written = $file->fwrite('readable content');
-
-echo "Wrote $written bytes to file: " . $file->getPathname();

--- a/test/index.php
+++ b/test/index.php
@@ -1,3 +1,16 @@
 <?php
 
+$testFile = isset($_GET['testFile']) && $_GET['testFile'] === 'true' ? true : false;
+
+if ($testFile === true) {
+    echo '<h2>whoami? ' . shell_exec('whoami') . '</h2>';
+
+    $file = new \SplFileObject('/tmp/temptestfile', "w");
+    $written = $file->fwrite('readable content');
+    
+    echo "Wrote $written bytes to file: " . $file->getPathname();
+
+    exit;
+}
+
 phpinfo();


### PR DESCRIPTION
In the previous setup Nginx had to have all php files within it's
document root as well, for php project it is not useful once there
is no intent to server static files via php/nginx projects, with
this setup now it's no necessary to share php files with nginx
anymore.