### PR TITLE
Disable healthcheck for base images

### DIFF
--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -35,6 +35,10 @@ STOPSIGNAL SIGTERM
 
 ENTRYPOINT ["/usr/local/bin/shush", "exec", "docker-php-entrypoint"]
 
+# Base images don't need healthcheck since they are not running applications
+# this can be overriden in the child images
+HEALTHCHECK NONE
+
 ## CLI-DEV STAGE ##
 FROM cli as cli-dev
 

--- a/Dockerfile-fpm
+++ b/Dockerfile-fpm
@@ -33,6 +33,10 @@ STOPSIGNAL SIGTERM
 
 CMD ["/usr/local/bin/shush", "exec", "php-fpm", "--force-stderr"]
 
+# Base images don't need healthcheck since they are not running applications
+# this can be overriden in the child images
+HEALTHCHECK NONE
+
 VOLUME [ "/var/run" ]
 
 ## FPM-DEV STAGE ##

--- a/Dockerfile-http
+++ b/Dockerfile-http
@@ -21,6 +21,10 @@ COPY src/http/nginx/conf/ /etc/nginx/
 
 CMD ["docker-nginx-entrypoint"]
 
+# Base images don't need healthcheck since they are not running applications
+# this can be overriden in the child images
+HEALTHCHECK NONE
+
 FROM http as http-dev
 
 ENV NGINX_EXPOSE_VERSION=on


### PR DESCRIPTION
Some Docker scanning tools are complaining about the fact we have no healthcheck, since this is a base image and not a service I'm disabling it with the intent to show it's not meant to exist. Any image inheriting from ours can override this configuration

![screenshot from 2018-09-03 08-47-49](https://user-images.githubusercontent.com/823634/44971497-11792380-af56-11e8-9036-3a5542da6b33.png)
