### PR TITLE
Disable logging compression

### DIFF
--- a/src/http/nginx/conf/nginx.conf.template
+++ b/src/http/nginx/conf/nginx.conf.template
@@ -17,7 +17,7 @@ http {
                     '${ESCAPE}status ${ESCAPE}body_bytes_sent "${ESCAPE}http_referer" '
                     '"${ESCAPE}http_user_agent" "${ESCAPE}http_x_forwarded_for"';
 
-    access_log /var/log/nginx/access.log gzip buffer=32k;
+    access_log /var/log/nginx/access.log;
     error_log /var/log/nginx/error.log notice;
 
     sendfile    on;


### PR DESCRIPTION
Context
=======

Since the log is redirected to stdout, using gzip and buffer causes a delay for the logs to show up, it accumulates for instance 32k and then sends it all to the file, since other tools are taking care of the logs
this feature isn't necessary and we have real time logs when tailing the container.

How to test
=======

- `make build-http`
- `docker run -d -p 8080:80 --rm usabillabv/php:nginx`
- `docker logs -f NEW_CONTAINER_ID 2&>/dev/null`
- open http://localhost:8080
- See there's no delay between making requests and the access log being printed out
