### PR TITLE
Update CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
     jobs: *default_workflow_jobs
     triggers:
       - schedule:
-          cron: "0 3 * * *"
+          cron: "0 3 */2 * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 default_workflow_jobs: &default_workflow_jobs
   - lint
@@ -76,6 +76,33 @@ workflows:
               only:
                 - master
 
+commands:
+  update_docker_compose:
+    description: "Update Docker Compose"
+    parameters:
+      version:
+        type: string
+        default: "1.22.0"
+    steps:
+      - run: sudo curl -L https://github.com/docker/compose/releases/download/<< parameters.version >>/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+      - run: sudo chmod +x /usr/local/bin/docker-compose
+  docker_load:
+    description: "Load Docker images from file"
+    parameters:
+      image:
+        type: string
+    steps:
+      - run: docker load -i ./tmp/usabillabv_php-<< parameters.image >>.tar
+  docker_load_all:
+    description: "Load all available docker images"
+    steps:
+      - docker_load:
+          image: http
+      - docker_load:
+          image: fpm
+      - docker_load:
+          image: cli
+
 jobs:
   lint:
     machine: true
@@ -93,14 +120,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: ./tmp
-      - run:
-          name: Update Docker Compose
-          command: |
-            sudo curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
-            sudo chmod +x /usr/local/bin/docker-compose
-      - run: docker load -i ./tmp/usabillabv_php-http.tar
-      - run: docker load -i ./tmp/usabillabv_php-fpm.tar
-      - run: docker load -i ./tmp/usabillabv_php-cli.tar
+      - update_docker_compose:
+          version: "1.22.0"
+      - docker_load_all
       - run: make ci-test-cli
       - store_test_results:
           path: ./test/test-results/
@@ -115,9 +137,7 @@ jobs:
           command: |
             sudo curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
             sudo chmod +x /usr/local/bin/docker-compose
-      - run: docker load -i ./tmp/usabillabv_php-http.tar
-      - run: docker load -i ./tmp/usabillabv_php-fpm.tar
-      - run: docker load -i ./tmp/usabillabv_php-cli.tar
+      - docker_load_all
       - run: make ci-test-fpm
       - store_test_results:
           path: ./test/test-results/
@@ -127,19 +147,14 @@ jobs:
       - checkout
       - attach_workspace:
           at: ./tmp
-      - run:
-          name: Update Docker Compose
-          command: |
-            sudo curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
-            sudo chmod +x /usr/local/bin/docker-compose
+      - update_docker_compose:
+          version: "1.22.0"
       - run:
           name: Install clair-scanner
           command: |
             sudo curl -L https://github.com/arminc/clair-scanner/releases/download/v8/clair-scanner_linux_amd64 -o /usr/local/bin/clair-scanner
             sudo chmod +x /usr/local/bin/clair-scanner
-      - run: docker load -i ./tmp/usabillabv_php-http.tar
-      - run: docker load -i ./tmp/usabillabv_php-fpm.tar
-      - run: docker load -i ./tmp/usabillabv_php-cli.tar
+      - docker_load_all
       - run: make ci-scan-vulnerability
       - store_artifacts:
           path: ./tmp/clair
@@ -185,7 +200,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: ./tmp
-      - run: docker load -i ./tmp/usabillabv_php-http.tar
+      - docker_load:
+          image: http
       - run: make ci-push-http
   push-cli:
     machine: true
@@ -193,7 +209,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: ./tmp
-      - run: docker load -i ./tmp/usabillabv_php-cli.tar
+      - docker_load:
+          image: cli
       - run: make ci-push-cli
   push-fpm:
     machine: true
@@ -201,5 +218,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: ./tmp
-      - run: docker load -i ./tmp/usabillabv_php-fpm.tar
+      - docker_load:
+          image: fpm
       - run: make ci-push-fpm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,9 @@ default_workflow_jobs: &default_workflow_jobs
         - build-http
         - build-fpm
         - build-cli
-  - push-http:
+
+push_workflow_jobs: &push_workflow_jobs
+  - push-http: &push-http
       context: dockerhub
       filters:
         branches:
@@ -40,7 +42,7 @@ default_workflow_jobs: &default_workflow_jobs
         - test-cli
         - test-fpm
         - scan-vulnerability
-  - push-fpm:
+  - push-fpm: &push-fpm
       context: dockerhub
       filters:
         branches:
@@ -50,8 +52,7 @@ default_workflow_jobs: &default_workflow_jobs
         - test-cli
         - test-fpm
         - scan-vulnerability
-        
-  - push-cli:
+  - push-cli: &push-cli
       context: dockerhub
       filters:
         branches:
@@ -62,12 +63,27 @@ default_workflow_jobs: &default_workflow_jobs
         - test-fpm
         - scan-vulnerability
 
+push_workflow_jobs_approval: &push_workflow_jobs_approval
+  - push-http:
+    <<: *push-http
+    type: approval
+  - push-fpm:
+    <<: *push-fpm
+    type: approval
+  - push-cli:
+    <<: *push-http
+    type: approval
+
 workflows:
   version: 2
   lint-build-test-push:
-    jobs: *default_workflow_jobs
+    jobs: 
+      <<: *default_workflow_jobs
+      <<: *push_workflow_jobs
   nightly:
-    jobs: *default_workflow_jobs
+    jobs: 
+      <<: *default_workflow_jobs
+      <<: *default_workflow_jobs
     triggers:
       - schedule:
           cron: "0 3 */2 * *"


### PR DESCRIPTION
## Context
- Leverage on reusable commands https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands
- Set push images as manual job
- Make the nightly build now as 3 times a week

The amount of pushes was too often specially after merging documentation and smaller things, if necessary the push step is going to be manual, otherwise it'll be automatically push in a couple of days