### PR TITLE
Move NGINX document root to /opt/project/public

### DIFF
--- a/Dockerfile-http
+++ b/Dockerfile-http
@@ -6,7 +6,7 @@ RUN set -x \
     && adduser -u 1000 -D -G app app
 
 # Env definition
-ENV NGINX_DOCUMENT_ROOT="/var/www/html"
+ENV NGINX_DOCUMENT_ROOT="/opt/project/public"
 ENV NGINX_SERVER_NAME=localhost
 ENV NGINX_WORKERS_PROCESSES=1
 ENV NGINX_WORKERS_CONNECTIONS=1024

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ In usual cases it might not be necessary to extend the nginx images, unless you 
 
 ### Document root configuration
 
-Nginx is configured with only one virtual host, which is using `/var/www/html` as document root. Ideally we should change this configuration to point to the `public` directory of our project, so that we expose only what's necessary.
+Nginx is configured with only one virtual host, which is using `/opt/project/public` as document root. Ideally we should change this configuration to point to the `public` directory of our project, so that we expose only what's necessary.
 
 In order to do this you should override `NGINX_DOCUMENT_ROOT` environment variable in the `Dockerfile`, e.g.:  
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     image: usabillabv/php:7.2-fpm-alpine3.8
     volumes:
       - fpm-sock:/var/run
-      - ./test/functional/web:/var/www/html
+      - ./test/functional/web:/opt/project/public
     networks:
       - backend-php
   nginx:


### PR DESCRIPTION
# Usabilla PHP Docker Template

Reviewers: @rdohms @rodrigorigotti @MLKiiwy @renatomefi @frankkoornstra @gPinato @dsantang @singhanee @cvmiert

## Type

- [ ] Apply CVE Patch
- [ ] Remove CVE Patch (fix on parent image)
- [ ] Build feature
- [x] Dockerfile improvement

## Changelog

- Move NGINX document root to /opt/project/public
