### PR TITLE
Enable PHP 7.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ build-cli: BUILDINGIMAGE=cli
 build-cli: clean-tags
 	./build-php.sh cli 7.2 3.7
 	./build-php.sh cli 7.2 3.8
-	# ./build-php.sh cli 7.3-rc 3.8
+	./build-php.sh cli 7.3 3.8
 
 build-fpm: BUILDINGIMAGE=fpm
 build-fpm: clean-tags
 	./build-php.sh fpm 7.2 3.7
 	./build-php.sh fpm 7.2 3.8
-	# ./build-php.sh fpm 7.3-rc 3.8
+	./build-php.sh fpm 7.3 3.8
 
 # Docker HTTP images build matrix ./build-nginx.sh (nginx version) (extra tag)
 build-http: BUILDINGIMAGE=http

--- a/src/php/utils/docker/docker-php-dev-mode
+++ b/src/php/utils/docker/docker-php-dev-mode
@@ -29,7 +29,7 @@ case "$1" in
 			exit 1
 		fi
 
-		pecl install xdebug
+		pecl install xdebug-beta
 		docker-php-ext-enable xdebug
 		apk del $apkDel
 


### PR DESCRIPTION
# Usabilla PHP Docker Template

Closes OPS-
Reviewers: @rdohms @rodrigorigotti @MLKiiwy @renatomefi @frankkoornstra @gPinato @dsantang @singhanee @cvmiert

## Type

- [ ] Apply CVE Patch
- [ ] Remove CVE Patch (fix on parent image)
- [ ] Build feature
- [ ] Dockerfile improvement

## Changelog

- Enable PHP 7.3-rc
