### PR TITLE
Add helper script to install RD Kafka extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,3 +286,7 @@ RUN set -x \
     && docker-php-ext-enable mongodb \
     && apk del .build-deps
 ```
+
+#### RD Kafka
+
+Since the RD Kafka extension is used across multiple projects, a helper script is provided to install both the dependencies and the extension in a uniform fashion. Run `docker-php-ext-rdkafka` to profit. 

--- a/src/php/utils/docker/docker-php-ext-rdkafka
+++ b/src/php/utils/docker/docker-php-ext-rdkafka
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -xe
+
+# shellcheck disable=SC2086
+apk add --no-cache --virtual .build-deps $PHPIZE_DEPS
+apk add --no-cache librdkafka-dev
+
+pecl install rdkafka
+
+docker-php-ext-enable rdkafka
+
+apk del .build-deps

--- a/test/container/test_helper_scripts.py
+++ b/test/container/test_helper_scripts.py
@@ -8,6 +8,7 @@ def test_php_images_contain_helper_scripts(host):
         "/usr/local/bin/docker-php-ext-install",
         "/usr/local/bin/docker-php-ext-enable",
         "/usr/local/bin/docker-php-ext-configure",
+        "/usr/local/bin/docker-php-ext-rdkafka",
         "/usr/local/bin/docker-php-entrypoint",
         "/usr/local/bin/php-fpm-healthcheck",
     ]
@@ -45,3 +46,9 @@ def test_php_fpm_status_is_enabled(host):
     health_check = host.run("php-fpm-healthcheck -v")
     assert health_check.rc == 0
     assert "pool:" in health_check.stdout
+
+@pytest.mark.php
+def test_php_source_tarball_script(host):
+    host.run_expect([0], "docker-php-ext-rdkafka")
+
+    assert 'rdkafka' in host.run('php -m').stdout


### PR DESCRIPTION
As well as the needed dependencies. Using projects only need to call
docker-php-ext-rdkafka to enable the RD Kafka extension.

# Usabilla PHP Docker Template

Reviewers: @rdohms @rodrigorigotti @MLKiiwy @renatomefi @frankkoornstra @gPinato @dsantang @singhanee @cvmiert 

## Type

- [ ] Apply CVE Patch
- [ ] Remove CVE Patch (fix on parent image)
- [ ] Build feature
- [x] Dockerfile improvement

## Changelog

- Adds a helper script to uniformly install the RD Kafka extension and its dependencies.
