### PR TITLE
Add fallback GPG keyservers

### DIFF
--- a/src/php/utils/docker/docker-php-source-tarball
+++ b/src/php/utils/docker/docker-php-source-tarball
@@ -33,7 +33,9 @@ case "$1" in
 		GNUPGHOME="$(mktemp -d)";
 		export GNUPGHOME;
 		for key in $GPG_KEYS; do
-			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key";
+			( gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys "$key" \
+			|| gpg --keyserver pgp.mit.edu --recv-keys "$key" \
+			|| gpg --keyserver keyserver.pgp.com --recv-keys "$key" )
 		done;
 		gpg --batch --verify php.tar.xz.asc php.tar.xz;
 		command -v gpgconf > /dev/null && gpgconf --kill all;


### PR DESCRIPTION
The download for GPG keys was very flaky so this adds some fallbacks as
well as switching the sks-keyservers one to IPv4 since we don't have
IPv6 connectivity in the containers.

# Usabilla PHP Docker Template

Reviewers: @rdohms @WyriHaximus @rodrigorigotti @MLKiiwy @renatomefi @frankkoornstra @gPinato @dsantang @singhanee @cvmiert

## Type

- [ ] Apply CVE Patch
- [ ] Remove CVE Patch (fix on parent image)
- [ ] Build feature
- [x] Dockerfile improvement

## Changelog

- Added GPG fallback servers
