### PR TITLE
Reaplly curl patch, add libxml2 patch

### DIFF
--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -20,6 +20,9 @@ RUN set -x \
     && docker-php-source-tarball clean && rm /usr/local/bin/php-cgi && rm /usr/local/bin/phpdbg && rm -rf /tmp/pear ~/.pearrc \
     && apk del .phpize-deps
 
+# Patch CVE-2018-14618 (curl), CVE-2018-16842 (libxml2)
+RUN apk upgrade --no-cache curl libxml2
+
 COPY src/gpg /usr/local/etc/gpg
 COPY src/php/conf/ /usr/local/etc/php/conf.d/
 COPY src/php/cli/conf/*.ini /usr/local/etc/php/conf.d/

--- a/Dockerfile-fpm
+++ b/Dockerfile-fpm
@@ -21,6 +21,9 @@ RUN apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
     && apk del .phpize-deps \
     && apk add --no-cache fcgi
 
+# Patch CVE-2018-14618 (curl), CVE-2018-16842 (libxml2)
+RUN apk upgrade --no-cache curl libxml2
+
 COPY src/gpg /usr/local/etc/gpg
 COPY src/php/conf/ /usr/local/etc/php/conf.d/
 COPY src/php/fpm/conf/*.conf /usr/local/etc/php-fpm.d/


### PR DESCRIPTION
Curl is still vulnerable in Alpine 3.7.

# Usabilla PHP Docker Template

Reviewers: @fabiotc @rdohms @WyriHaximus @rodrigorigotti @MLKiiwy @renatomefi @frankkoornstra @gPinato @dsantang @agustingomes @singhanee @cvmiert

## Type

- [x] Apply CVE Patch
- [ ] Remove CVE Patch (fix on parent image)
- [ ] Build feature
- [ ] Dockerfile improvement

## Changelog

- 
