### PR TITLE
Propagate SIGTERM to nginx

### DIFF
--- a/src/http/nginx/docker-nginx-entrypoint
+++ b/src/http/nginx/docker-nginx-entrypoint
@@ -2,6 +2,6 @@
 set -e
 
 ## From the environment variables replace the nginx configuration placeholders
-ESCAPE='$' envsubst < /etc/nginx/vhost.conf.template > /etc/nginx/conf.d/default.conf \
-    && ESCAPE='$' envsubst < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf \
-    && nginx -g 'daemon off;'
+ESCAPE='$' envsubst < /etc/nginx/vhost.conf.template > /etc/nginx/conf.d/default.conf
+ESCAPE='$' envsubst < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+exec nginx -g 'daemon off;'


### PR DESCRIPTION
# Usabilla PHP Docker Template

Reviewers: @fabiotc @rdohms @WyriHaximus @renatomefi @frankkoornstra @agustingomes @cvmiert

## Context

Nginx is currently not receiving the SIGTERM for the orchestrator, forcing it to be killed

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| yes
| Build feature?    | no
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

## Changelog

- [x] Ensure nginx receives SIGTERM
