### PR TITLE
PHP-FPM translate Kill Signals

### DIFF
--- a/Dockerfile-fpm
+++ b/Dockerfile-fpm
@@ -40,7 +40,8 @@ RUN install-shush && rm -f /usr/local/bin/install-shush \
 
 STOPSIGNAL SIGTERM
 
-CMD ["/usr/local/bin/shush", "exec", "php-fpm", "--force-stderr"]
+ENTRYPOINT [ "docker-php-entrypoint-init" ]
+CMD ["--force-stderr"]
 
 # Base images don't need healthcheck since they are not running applications
 # this can be overriden in the child images
@@ -54,6 +55,3 @@ FROM fpm as fpm-dev
 # Install Xdebug and development specific configuration
 RUN docker-php-dev-mode xdebug \
     && docker-php-dev-mode config
-
-# Change entrypoint back to the default because we don't need shush in development
-CMD ["docker-php-entrypoint", "--force-stderr"]

--- a/Dockerfile-fpm
+++ b/Dockerfile-fpm
@@ -9,6 +9,7 @@ RUN set -x \
 
 # Install docker help scripts
 COPY src/php/utils/docker/ /usr/local/bin/
+COPY src/php/utils/install-* /usr/local/bin/
 
 # Install PHP extensions
 RUN apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
@@ -32,13 +33,10 @@ COPY src/gpg /usr/local/etc/gpg
 COPY src/php/conf/ /usr/local/etc/php/conf.d/
 COPY src/php/fpm/conf/*.conf /usr/local/etc/php-fpm.d/
 
-# Install shush
-COPY src/php/utils/install-shush /usr/local/bin/
-RUN install-shush && rm -rf /usr/local/bin/install-shush
-
-# Install composer
-COPY src/php/utils/install-composer /usr/local/bin/
-RUN install-composer && rm -rf /usr/local/bin/install-composer
+# Install shush, dumb-init and composer
+RUN install-shush && rm -f /usr/local/bin/install-shush \
+    && install-dumb-init && rm -f /usr/local/bin/install-dumb-init \
+    && install-composer && rm -f /usr/local/bin/install-composer
 
 STOPSIGNAL SIGTERM
 

--- a/src/php/utils/docker/docker-php-entrypoint-init
+++ b/src/php/utils/docker/docker-php-entrypoint-init
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option` or if it's empty
+if [ -z "$1" ] || [ "${1#-}" != "$1" ]; then
+	set -- php-fpm "$@"
+fi
+
+if [ "$1" = php-fpm ]; then
+    if env | grep -E "^KMS_ENCRYPTED"; then
+        set -- shush exec -- "$@"
+    fi
+
+    # Rewrite SIGINT  to SIGQUIT
+    # Rewrite SIGTERM to SIGQUIT
+    # Rewrite SIGHUP  to SIGUSR2
+    set -- dumb-init --rewrite 2:3 --rewrite 15:3 --rewrite 1:17 -- "$@"
+fi
+
+exec "$@"

--- a/src/php/utils/install-dumb-init
+++ b/src/php/utils/install-dumb-init
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -xeu
+
+VERSION="1.2.2"
+
+curl -sL -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v"$VERSION"/dumb-init_"$VERSION"_amd64
+
+chmod +x /usr/local/bin/dumb-init
+
+dumb-init --version
+
+RESULT=$?
+
+exit $RESULT

--- a/test/container/php/test_fpm_entrypoint.py
+++ b/test/container/php/test_fpm_entrypoint.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.mark.php_fpm_exec
+def test_php_fpm_exec_has_dumb_init(host):
+    php_fpm_exec = host.run("ps 1")
+
+    assert "dumb-init" in php_fpm_exec.stdout
+    assert "--rewrite 2:3" in php_fpm_exec.stdout
+    assert "--rewrite 15:3" in php_fpm_exec.stdout
+    assert "--rewrite 1:17" in php_fpm_exec.stdout
+
+    assert "shush" not in php_fpm_exec.stdout

--- a/test/container/php/test_helper_scripts.py
+++ b/test/container/php/test_helper_scripts.py
@@ -11,6 +11,7 @@ def test_php_images_contain_helper_scripts(host):
         "/usr/local/bin/docker-php-ext-pdo-pgsql",
         "/usr/local/bin/docker-php-ext-rdkafka",
         "/usr/local/bin/docker-php-entrypoint",
+        "/usr/local/bin/docker-php-entrypoint-init",
         "/usr/local/bin/php-fpm-healthcheck",
     ]
 


### PR DESCRIPTION
# Usabilla PHP Docker Template

Reviewers: @fabiotc @rdohms @WyriHaximus @renatomefi @frankkoornstra @agustingomes @cvmiert

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | yes
| Dockerfile change?| yes

## Changelog

- Introduce dumb-init in order to rewrite signals wrongly handled by PHP-FPM
- Replace entrypoint while keeping compatibility to the original PHP image one
- [x] Document
