### PR TITLE
Fix missing context for prometheus exporter push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ version: 2.1
         - build-http
         - build-fpm
         - build-cli
+        - build-prometheus-exporter-file
   - test-http-e2e: *test-http
   - test-prometheus-exporter-file-e2e: &test-prometheus-exporter-file-e2e
       requires:


### PR DESCRIPTION
# Usabilla PHP Docker Template

Reviewers: @fabiotc @rdohms @WyriHaximus @renatomefi @frankkoornstra @agustingomes @cvmiert

## Type

| Q                 | A
| ----------------- | -----
| Build feature?    | yes

## Changelog

- CircleCI will only share context if the requirements are correct, this
adds a missing requirement in the chain in order to push the images at
the end.
