### PR TITLE
Install all PHP extensions in one command

### DIFF
--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -11,8 +11,7 @@ COPY src/php/utils/docker/ /usr/local/bin/
 # Install PHP extensions
 RUN set -x \
     && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
-    && docker-php-ext-install pcntl \
-    && docker-php-ext-install opcache \
+    && docker-php-ext-install pcntl opcache \
     && pecl install apcu \
     && pecl clear-cache \
     && docker-php-ext-enable apcu \


### PR DESCRIPTION
By doing those in one command the required packages only have to be
downloaded and then removed once. If you would do one extension per
docker-php-ext-install it would download all the required packages to
build a PHP extension each time the command is invoked. By building them
 using the same command we gain a small but exponential performance gain
 (and save bandwidth as a nice bonus) for each extension for each
 extension we add to the image.

This PR is a backport of https://github.com/WyriHaximusNet/docker-php/pull/8 where this change shaved off 40 to 60 seconds per `build-*` step.

# Usabilla PHP Docker Template

Reviewers: @fabiotc @rdohms @WyriHaximus @renatomefi @frankkoornstra @agustingomes @cvmiert

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| yes
| Build feature?    | yes
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

## Changelog

- Speed up cli build by bundling all `docker-php-ext-install` calls into one
