### PR TITLE
Set custom logging format for Nginx

### DIFF
--- a/src/http/nginx/conf/main/nginx.conf.template
+++ b/src/http/nginx/conf/main/nginx.conf.template
@@ -13,11 +13,14 @@ http {
     include       /etc/nginx/mime.types;
     default_type  text/plain;
 
-    log_format gzip '${ESCAPE}remote_addr - ${ESCAPE}remote_user [${ESCAPE}time_local] "${ESCAPE}request" '
-                    '${ESCAPE}status ${ESCAPE}body_bytes_sent "${ESCAPE}http_referer" '
-                    '"${ESCAPE}http_user_agent" "${ESCAPE}http_x_forwarded_for"';
+    log_format custom  '${ESCAPE}remote_addr - ${ESCAPE}remote_user [${ESCAPE}time_local] "${ESCAPE}request" '
+                       '${ESCAPE}status ${ESCAPE}body_bytes_sent '
+                       '"${ESCAPE}http_referer" "${ESCAPE}http_user_agent" '
+                       '"X-Forwarded-For: ${ESCAPE}http_x_forwarded_for" '
+                       '"Accept: ${ESCAPE}http_accept" '
+                       '"Accept-Encoding: ${ESCAPE}http_accept_encoding"';
 
-    access_log /dev/stdout;
+    access_log /dev/stdout custom;
     error_log stderr notice;
 
     sendfile    on;


### PR DESCRIPTION
# Usabilla PHP Docker Template

Reviewers: @fabiotc @rdohms @WyriHaximus @renatomefi @frankkoornstra @agustingomes @cvmiert

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Dockerfile change?| yes

## Changelog

- This way it's easier to get extra information and debug It follows the default `combined` format from Nginx and adds a few extra ones: http://nginx.org/en/docs/http/ngx_http_log_module.html
