### PR TITLE
Move the location.d include to the rewrite

### DIFF
--- a/src/http/nginx/conf/php-fpm/vhost.conf.template
+++ b/src/http/nginx/conf/php-fpm/vhost.conf.template
@@ -12,12 +12,12 @@ server {
     }
     
     location / {
-        include /etc/nginx/location.d-enabled/*.conf;
-        
         rewrite ^ /index.php last;
     }
 
     location ~ \.php$ {
+        include /etc/nginx/location.d-enabled/*.conf;
+        
         fastcgi_pass   unix:/var/run/php-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
 


### PR DESCRIPTION
# Usabilla PHP Docker Template

Reviewers: @fabiotc @rdohms @WyriHaximus @renatomefi @frankkoornstra @agustingomes @cvmiert

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Dockerfile change?| yes

## Changelog

- Move the location.d include to the rewrite: This way the headers will be added to the final response. When a redirect happens the added headers won't be persisted through the whole process, thus we need to make sure it's in the final location block, by doing it before it reaches fcgi we ensure we can also intercept the OPTIONS request