### PR TITLE
Add wget in order to fix php package download

### DIFF
--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -10,6 +10,7 @@ COPY src/php/utils/docker/ /usr/local/bin/
 
 # Install PHP extensions
 RUN set -x \
+    && apk add --no-cache wget \
     && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
     && docker-php-ext-install pcntl opcache \
     && pecl install apcu \

--- a/Dockerfile-fpm
+++ b/Dockerfile-fpm
@@ -12,7 +12,9 @@ COPY src/php/utils/docker/ /usr/local/bin/
 COPY src/php/utils/install-* /usr/local/bin/
 
 # Install PHP extensions
-RUN apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+RUN set -x \
+    && apk add --no-cache wget \
+    && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
     && docker-php-ext-install opcache \
     && pecl install apcu \
     && pecl clear-cache \


### PR DESCRIPTION
# Usabilla PHP Docker Template

Reviewers: @fabiotc @rdohms @WyriHaximus @renatomefi @frankkoornstra @agustingomes @cvmiert

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Dockerfile change?| yes

## Changelog

- Add `wget`: The busybox implementation is erroring at OCSP level: `php.net: ocsp verify failed` by installing the full wget it does the resolution correctly
