### PR TITLE
fix(nginx.cors): remove wildcard because of browsers compatibility issues - see BLUP-738

### DIFF
--- a/src/http/nginx/conf/main/location.d-available/cors.conf.template
+++ b/src/http/nginx/conf/main/location.d-available/cors.conf.template
@@ -1,9 +1,9 @@
 # Allow CORS if environment variable is set
 add_header 'Access-Control-Allow-Origin' "${NGINX_CORS_ALLOW_ORIGIN}" always;
 add_header 'Access-Control-Allow-Credentials' 'true' always;
-add_header 'Access-Control-Allow-Methods' "*" always;
-add_header 'Access-Control-Allow-Headers' "*" always;
-add_header 'Access-Control-Expose-Headers' "*" always;
+add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, PATCH, DELETE' always;
+add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
+add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
 
 if (${ESCAPE}request_method = 'OPTIONS') {
     # Pre fligh information is valid for an hour
@@ -14,9 +14,9 @@ if (${ESCAPE}request_method = 'OPTIONS') {
     # Default CORS headers (have to be reapeated, no inheritance from upper scope)
     add_header 'Access-Control-Allow-Origin' "${NGINX_CORS_ALLOW_ORIGIN}" always;
     add_header 'Access-Control-Allow-Credentials' 'true' always;
-    add_header 'Access-Control-Allow-Methods' "*" always;
-    add_header 'Access-Control-Allow-Headers' "*" always;
-    add_header 'Access-Control-Expose-Headers' "*" always;
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, PATCH, DELETE' always;
+    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
+    add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
 
     return 204;
 }


### PR DESCRIPTION
# CORS issue on all browsers except Firefox

According to the documentation of the header **Access-Control-Allow-Headers**
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers#Compatibility_notes
The wildcard is not supported by all the browsers so cannot be really used.

Same for **Access-Control-Expose-Headers**, https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers#Compatibility_notes

Same for **Access-Control-Allow-Methods**, https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods#Compatibility_notes

So I change the value for a list of headers, I use a list found here: https://enable-cors.org/server_nginx.html

=> For the value of **Access-Control-Allow-Methods**, I'm not sure of the list of method used on our API. @rodrigorigotti @chiel can you confirm my list?

# Usabilla PHP Docker Template

Reviewers: @fabiotc @rdohms @WyriHaximus @renatomefi @frankkoornstra @agustingomes @cvmiert

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| yes
| Build feature?    | no
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

## Changelog

- Please make sure you have checked our [Contributing guidelines](https://github.com/usabilla/php-docker-template/blob/master/.github/CONTRIBUTING.md)
