### PR TITLE
Add Alpine 3.10 to build matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,16 +19,20 @@ build-cli: clean-tags
 	./build-php.sh cli 7.2 3.7
 	./build-php.sh cli 7.2 3.8
 	./build-php.sh cli 7.2 3.9
+	./build-php.sh cli 7.2 3.10
 	./build-php.sh cli 7.3 3.8
 	./build-php.sh cli 7.3 3.9
+	./build-php.sh cli 7.3 3.10
 
 build-fpm: BUILDINGIMAGE=fpm
 build-fpm: clean-tags
 	./build-php.sh fpm 7.2 3.7
 	./build-php.sh fpm 7.2 3.8
 	./build-php.sh fpm 7.2 3.9
+	./build-php.sh fpm 7.2 3.10
 	./build-php.sh fpm 7.3 3.8
 	./build-php.sh fpm 7.3 3.9
+	./build-php.sh fpm 7.3 3.10
 
 # Docker HTTP images build matrix ./build-nginx.sh (nginx version) (extra tag)
 build-http: BUILDINGIMAGE=http


### PR DESCRIPTION
# Usabilla PHP Docker Template

Reviewers: @fabiotc @rdohms @WyriHaximus @renatomefi @frankkoornstra @agustingomes @cvmiert

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | ~yes~/no
| Dockerfile change?| ~yes~/no
| Build feature?    | yes/~no~
| Apply CVE Patch?  | ~yes~/no
| Remove CVE Patch? | ~yes~/no

## Changelog

- Added [Alpine 3.10](https://alpinelinux.org/posts/Alpine-3.10.0-released.html) to the build matrix for PHP 7.2 & 7.3
