### PR TITLE
Give FPM and CLI unlimited memory

### DIFF
--- a/src/php/cli/conf/cli.ini
+++ b/src/php/cli/conf/cli.ini
@@ -1,3 +1,2 @@
-memory_limit=1024M
 opcache.enable_cli=1
 apc.enable_cli=1

--- a/src/php/conf/default.ini
+++ b/src/php/conf/default.ini
@@ -1,5 +1,7 @@
 date.timezone=UTC
 
+memory_limit=-1
+
 opcache.fast_shutdown=1
 opcache.max_wasted_percentage=10
 opcache.validate_timestamps=0

--- a/test/container/php/test_config.py
+++ b/test/container/php/test_config.py
@@ -53,9 +53,15 @@ def test_development_config_is_effective(host):
 def test_cli_configuration_is_effective(host):
     config = get_config(host)
 
-    assert u'memory_limit => 1024M => 1024M' in config
+    assert u'memory_limit => -1 => -1' in config
     assert u'opcache.enable_cli => On => On' in config
     assert u'apc.enable_cli => On => On' in config
+
+@pytest.mark.php_fpm
+def test_fpm_configuration_is_effective(host):
+    config = get_config(host)
+
+    assert u'memory_limit => -1 => -1' in config
 
 def get_config(host):
     return host.run('php -i').stdout


### PR DESCRIPTION
Since both are run in Kubernetes, we can rely on the memory limits and
management there.

# Usabilla PHP Docker Template

Reviewers: @fabiotc @rdohms @WyriHaximus @renatomefi @frankkoornstra @agustingomes @cvmiert

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| no
| Build feature?    | no
| Apply CVE Patch?  | no
| Remove CVE Patch? | no