### PR TITLE
Support multiple tags for nginx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ build-fpm: clean-tags
 # Docker HTTP images build matrix ./build-nginx.sh (nginx version) (extra tag)
 build-http: BUILDINGIMAGE=http
 build-http: clean-tags
-	./build-nginx.sh 1.17 nginx
+	./build-nginx.sh 1.17 nginx1 nginx
 	./build-nginx.sh 1.16
 	./build-nginx.sh 1.15
 	./build-nginx.sh 1.14


### PR DESCRIPTION
Now it's possible to download by the major tag, for instance:
`usabillabv/php:nginx1`

# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Build feature?    | yes

## Changelog

- Allow to have extra tag aliases, useful for major versions for instance: `nginx, nginx1, nginx1.17`
