### PR TITLE
Treat lack of custom markers register

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -11,6 +11,7 @@ def pytest_addoption(parser):
 def tag(request):
     return request.config.getoption("--tag")
 
+
 @pytest.fixture
 def container(host, tag, request):
     port = '80'

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+markers =
+    php: base php tests, should pass in all flavors
+    php_no_dev: php tests where only works without dev configurations
+    php_dev: php tests where only works with dev configurations, i.e.: Xdebug
+    php_cli: php tests where the sapi is cli (`php_sapi_name()`)
+    php_fpm: php tests where the sapi is fpm
+    php_fpm_exec: fpm tests where there is access to the fpm container
+    nginx: nginx specific tests
+    nginx_e2e: nginx tests where http calls are made
+    nginx_fpm_functional: tests where nginx has access to php fpm via fcgi
+    prometheus_exporter_file_e2e: tests where the nginx prometheus exporter configuration is enabled


### PR DESCRIPTION
# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Build feature?    | yes

## Changelog

- The latest version of pytest requires that each custom marker should be
registered, since we use a lot of them to segment the tests the amount
of warnings is overwhelming, thus fixed.

Example:
```
=============================== warnings summary ===============================

/usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324

  /usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.php - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html

    PytestUnknownMarkWarning,



/usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324

  /usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.nginx - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html

    PytestUnknownMarkWarning,



/usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324

  /usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.php_no_dev - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html

    PytestUnknownMarkWarning,



/usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324

  /usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.php_dev - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html

    PytestUnknownMarkWarning,



/usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324

  /usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.php_cli - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html

    PytestUnknownMarkWarning,



/usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324

  /usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.php_fpm - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html

    PytestUnknownMarkWarning,



/usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324

  /usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.php_fpm_exec - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html

    PytestUnknownMarkWarning,



/usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324

  /usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.nginx_e2e - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html

    PytestUnknownMarkWarning,



/usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324

  /usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.prometheus_exporter_file_e2e - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html

    PytestUnknownMarkWarning,



/usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324

  /usr/lib/python3.6/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.nginx_fpm_functional - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html

    PytestUnknownMarkWarning,



-- Docs: https://docs.pytest.org/en/latest/warnings.html
```