### PR TITLE
Add hirak/prestissimo to speed up composer install

### DIFF
--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -42,6 +42,9 @@ RUN install-shush && rm -rf /usr/local/bin/install-shush
 COPY src/php/utils/install-composer /usr/local/bin/
 RUN install-composer && rm -rf /usr/local/bin/install-composer
 
+RUN composer global require hirak/prestissimo --ansi --no-progress \
+    && composer clear-cache
+
 STOPSIGNAL SIGTERM
 
 ENTRYPOINT ["/usr/local/bin/shush", "exec", "docker-php-entrypoint"]

--- a/Dockerfile-fpm
+++ b/Dockerfile-fpm
@@ -50,6 +50,9 @@ RUN install-shush && rm -f /usr/local/bin/install-shush \
     && install-dumb-init && rm -f /usr/local/bin/install-dumb-init \
     && install-composer && rm -f /usr/local/bin/install-composer
 
+RUN composer global require hirak/prestissimo --ansi --no-progress \
+    && composer clear-cache
+
 STOPSIGNAL SIGTERM
 
 ENTRYPOINT [ "docker-php-entrypoint-init" ]


### PR DESCRIPTION
Done this in my own images and it significantly speeds up composer
installs/requires/updates.

# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| yes
| Build feature?    | no
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

