### PR TITLE
Remove fastcgi_split_path_info from nginx config

### DIFF
--- a/src/http/nginx/conf/php-fpm/vhost.conf.template
+++ b/src/http/nginx/conf/php-fpm/vhost.conf.template
@@ -19,7 +19,6 @@ server {
         include /etc/nginx/location.d-enabled/*.conf;
         
         fastcgi_pass   unix:/var/run/php-fpm.sock;
-        fastcgi_split_path_info ^(.+\.php)(/.*)$;
 
         include        fastcgi_params;
 


### PR DESCRIPTION
This does nothing in the normal case because this location block only matches \.php$, and in the unlikely event that we have a path where the string ".php" appears multiple times, it could cause the wrong PHP file to be loaded.

# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| no
| Build feature?    | no
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

## Changelog

- Please make sure you have checked our [Contributing guidelines](https://github.com/usabilla/php-docker-template/blob/master/.github/CONTRIBUTING.md)
