### PR TITLE
Use PHP 7.3 and Alpine 3.10 during tests

### DIFF
--- a/test/functional/web/index.php
+++ b/test/functional/web/index.php
@@ -1,13 +1,13 @@
 <?php
 
-$testFile = isset($_GET['testFile']) && $_GET['testFile'] === 'true' ? true : false;
+$testFile = isset($_GET['testFile']) && $_GET['testFile'] === 'true';
 
 if ($testFile === true) {
     echo '<h2>whoami? ' . shell_exec('whoami') . '</h2>';
 
     $file = new \SplFileObject('/opt/project/public/tmp/temptestfile', "w");
     $written = $file->fwrite('readable content');
-    
+
     echo "Wrote $written bytes to file: " . $file->getPathname();
 
     exit;

--- a/test/inheritance/Dockerfile
+++ b/test/inheritance/Dockerfile
@@ -1,4 +1,4 @@
-FROM usabillabv/php:7.2-cli-alpine3.7 as compile-php-extension
+FROM usabillabv/php:7.3-cli-alpine3.10 as compile-php-extension
 
 RUN set -x \
     && apk add --no-cache gnupg postgresql-client postgresql-dev \
@@ -7,7 +7,7 @@ RUN set -x \
     && docker-php-source-tarball clean \
     && apk del gnupg postgresql-dev
 
-FROM usabillabv/php:7.2-cli-alpine3.7 as compile-php-pecl-extension
+FROM usabillabv/php:7.3-cli-alpine3.10 as compile-php-pecl-extension
 
 RUN set -x \
     && apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
@@ -15,4 +15,4 @@ RUN set -x \
     && docker-php-ext-enable xdebug \
     && pecl clear-cache \
     && docker-php-source-tarball clean \
-    && apk del .phpize-deps 
+    && apk del .phpize-deps


### PR DESCRIPTION
# Usabilla PHP Docker Template

Reviewers: @usabilla/professor @WyriHaximus @cvmiert 

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| yes (tests)
| Build feature?    | no
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

## Changelog

This changes the PHP and Alpine versions that we use for our tests.
