### PR TITLE
Replace PHP 7.4 RC with PHP 7.4 final

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build-cli: clean-tags
 	./build-php.sh cli 7.3 3.8
 	./build-php.sh cli 7.3 3.9
 	./build-php.sh cli 7.3 3.10
-	./build-php.sh cli 7.4-rc 3.10
+	./build-php.sh cli 7.4 3.10
 
 build-fpm: BUILDINGIMAGE=fpm
 build-fpm: clean-tags
@@ -34,7 +34,7 @@ build-fpm: clean-tags
 	./build-php.sh fpm 7.3 3.8
 	./build-php.sh fpm 7.3 3.9
 	./build-php.sh fpm 7.3 3.10
-	./build-php.sh fpm 7.4-rc 3.10
+	./build-php.sh fpm 7.4 3.10
 
 # Docker HTTP images build matrix ./build-nginx.sh (nginx version) (extra tag)
 build-http: BUILDINGIMAGE=http


### PR DESCRIPTION
As PHP 7.4 final is now available on Docker hub we can drop the RC and
use the final instead.

# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| yes
| Build feature?    | yes
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

