### PR TITLE
Clean up redundant PHP FPM pool configurations

### DIFF
--- a/Dockerfile-fpm
+++ b/Dockerfile-fpm
@@ -1,5 +1,7 @@
 FROM php:7.2-fpm-alpine3.7 as fpm
 
+RUN rm /usr/local/etc/php-fpm.d/*.conf
+
 ENV FCGI_CONNECT=/var/run/php-fpm.sock
 ENV PHP_FPM_PM=dynamic
 ENV PHP_FPM_PM_MAX_CHILDREN=5


### PR DESCRIPTION
Since we're generating a configuration from a template file there is no
need to keep upstream PHP FPM pool configuration files lying around
that could case issues down the line.

# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| yes
| Build feature?    | no
| Apply CVE Patch?  | no
| Remove CVE Patch? | no
