### PR TITLE
Use Xdebug stable channel

### DIFF
--- a/src/php/utils/docker/docker-php-dev-mode
+++ b/src/php/utils/docker/docker-php-dev-mode
@@ -29,7 +29,7 @@ case "$1" in
 			exit 1
 		fi
 
-		pecl install xdebug-beta
+		pecl install xdebug-stable
 		docker-php-ext-enable xdebug
 		apk del $apkDel
 


### PR DESCRIPTION
The beta channel has received the first preliminary release of Xdebug 3
Which will require to adapt it's settings to be compatible with the new
version.

# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| no
| Build feature?    | yes
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

## Changelog

- Use Xdebug stable channel instead of beta. CI pipelines could fail when tests depend on Xdebug functionality (like mutation tests) due to the Xdebug settings not being fully compatible with the [3.0.0beta1](https://pecl.php.net/package/xdebug/3.0.0beta1) release
