### PR TITLE
Add `--1` flag to Composer's installer

### DIFF
--- a/src/php/utils/install-composer
+++ b/src/php/utils/install-composer
@@ -13,7 +13,7 @@ then
     exit 1
 fi
 
-php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer
+php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer --1
 
 RESULT=$?
 


### PR DESCRIPTION
This flag will pin the major versions installed by Composer as 1.x,
while we prepare our services and dependencies to Composer V2 migration.

Reviewers: @usabilla/oss-docker 