### PR TITLE
Require latest v2 version of Xdebug

### DIFF
--- a/src/php/utils/docker/docker-php-dev-mode
+++ b/src/php/utils/docker/docker-php-dev-mode
@@ -29,7 +29,7 @@ case "$1" in
 			exit 1
 		fi
 
-		pecl install xdebug-stable
+		pecl install xdebug-2.9.8
 		docker-php-ext-enable xdebug
 		apk del $apkDel
 


### PR DESCRIPTION
This is a temporary restriction since we're transitioning soon
to Xdebug 3, but some changes will be needed prior to that.

# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| yes
| Build feature?    | no
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

## Changelog

- Use Xdebug v2.9.8 temporarily instead of stable channel containing the new v3. CI pipelines could fail when tests depend on Xdebug functionality (like mutation tests) due to the Xdebug settings not being fully compatible with the v3 release.
