### PR TITLE
Add log_level for FPM logs

### DIFF
--- a/src/php/fpm/conf/zz-docker.conf.template
+++ b/src/php/fpm/conf/zz-docker.conf.template
@@ -1,6 +1,9 @@
 [global]
 daemonize = no
 
+; Log level - wip - has to be in global
+log_level = ${PHP_FPM_GLOBAL_LOG_LEVEL}
+
 [www]
 ; Choose how the process manager will control the number of child processes.
 ; Possible Values:


### PR DESCRIPTION
# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | yes
| Dockerfile change?| no
| Build feature?    | yes
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

## Changelog

This change aims to add control over the log level outputted by FPM itself. I've noticed we have a high volume of logs with notice level that will look like this:

```log
"[22-Feb-2021 09:17:02] NOTICE: [pool www] child 10444 started"
"[22-Feb-2021 09:17:03] NOTICE: [pool www] child 10320 exited with code 0 after 17.567216 seconds from start"
"[22-Feb-2021 09:17:03] NOTICE: [pool www] child 10445 started"
"[22-Feb-2021 09:17:09] NOTICE: [pool www] child 10359 exited with code 0 after 16.352465 seconds from start"
"[22-Feb-2021 09:17:09] NOTICE: [pool www] child 10514 started"
"[22-Feb-2021 09:17:11] NOTICE: [pool www] child 10360 exited with code 0 after 17.717351 seconds from start"
"[22-Feb-2021 09:17:11] NOTICE: [pool www] child 10523 started"
"[22-Feb-2021 09:17:11] NOTICE: [pool www] child 10400 exited with code 0 after 17.065780 seconds from start"
```
The new variable added will allow us to control the minimum level we want our FPM processes to log. note that this logging is different than the one from the application itself.