### PR TITLE
Drop PHP 7.2 from build PHP versions list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         name: Generate PHP
         shell: bash
         run: |
-          echo "::set-output name=versions::[\"7.4\", \"7.3\", \"7.2\"]"
+          echo "::set-output name=versions::[\"7.4\", \"7.3\"]"
   php-type-matrix:
     name: PHP Type Matrix
     runs-on: ubuntu-latest


### PR DESCRIPTION
As per #165 we're no longer going to build this version. (Note that PHP 8 support is being worked on it #166.)

# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| no
| Build feature?    | no
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

## Changelog

- Please make sure you have checked our [Contributing guidelines](https://github.com/usabilla/php-docker-template/blob/master/.github/CONTRIBUTING.md)
