### PR TITLE
Add a sleep before running prometheus exporter e2e tests

### DIFF
--- a/test/e2e/test_prometheus_exporter_file.py
+++ b/test/e2e/test_prometheus_exporter_file.py
@@ -4,6 +4,9 @@ import requests
 
 @pytest.mark.prometheus_exporter_file_e2e
 def test_prometheus_exporter_file_propagates_content_type_text(host, container):
+    sleep = host.run('sleep 1')
+    assert sleep.rc is 0
+
     nginx_port = host.check_output("docker inspect " + container + " --format '{{ (index (index .NetworkSettings.Ports \"80/tcp\") 0).HostPort }}'")
 
     req_root = requests.get("http://localhost:{}/".format(nginx_port))
@@ -21,6 +24,9 @@ def test_prometheus_exporter_file_propagates_content_type_text(host, container):
 
 @pytest.mark.prometheus_exporter_file_e2e
 def test_prometheus_exporter_file_propagates_content_type_json(host, container):
+    sleep = host.run('sleep 1')
+    assert sleep.rc is 0
+
     nginx_port = host.check_output("docker inspect " + container + " --format '{{ (index (index .NetworkSettings.Ports \"80/tcp\") 0).HostPort }}'")
 
     req_root = requests.get("http://localhost:{}/".format(nginx_port))


### PR DESCRIPTION
This is a hotfix to get those tests working again. There seems to be a
race condition between the service in the container starting and the
tests needing them.

The permanent solution would be to check for X
seconds until the service is up and running before doing the tests and
failing if it's not up after those X seconds.

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| no
| Build feature?    | no
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

Reviewers: @usabilla/oss-docker