### PR TITLE
Update `realestate-com-au/shush` to `v1.5.0`

### DIFF
--- a/src/php/utils/install-shush
+++ b/src/php/utils/install-shush
@@ -2,7 +2,9 @@
 
 set -xe
 
-curl -sL -o /usr/local/bin/shush https://github.com/realestate-com-au/shush/releases/download/v1.3.4/shush_linux_amd64
+curl -sL -o /usr/local/bin/shush https://github.com/realestate-com-au/shush/releases/download/v1.5.0/shush_linux_amd64
+
+echo "cdec941dc5f45dda2d981169aa1845540d2c5bf98bfd1d8a85deaa6a6a43a4d1  /usr/local/bin/shush" | sha256sum -c
 
 chmod +x /usr/local/bin/shush
 


### PR DESCRIPTION
Perform a checksum on the downloaded `shush` executable to ensure it is
not corrupted.

Release notes:
https://github.com/realestate-com-au/shush/releases/tag/v1.5.0

# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| no
| Build feature?    | yes
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

## Changelog

- Supersedes #157

Reviewers: @renatomefi @WyriHaximus @carusogabriel @rdohms @stevenjm @gwkunze 