### PR TITLE
Build PHP 8.0 images for Alpine 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,12 @@ jobs:
           - php: "8.0"
             alpine: "3.14"
             type: fpm
+          - php: "8.0"
+            alpine: "3.15"
+            type: cli
+          - php: "8.0"
+            alpine: "3.15"
+            type: fpm
           - php: "8.1"
             alpine: "3.15"
             type: cli


### PR DESCRIPTION
This will help the teams, and the libraries, on the transition to PHP 8.1 which is only built on that Alpine version.

Reviewers: @usabilla/oss-docker
