### PR TITLE
Add entry for `php-8.0-alpine-3.15` in all places

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,12 @@ jobs:
           - php: "8.0"
             alpine: "3.14"
             type: fpm
+          - php: "8.0"
+            alpine: "3.15"
+            type: cli
+          - php: "8.0"
+            alpine: "3.15"
+            type: fpm
           - php: "8.1"
             alpine: "3.15"
             type: cli
@@ -331,6 +337,12 @@ jobs:
             type: cli
           - php: "8.0"
             alpine: "3.14"
+            type: fpm
+          - php: "8.0"
+            alpine: "3.15"
+            type: cli
+          - php: "8.0"
+            alpine: "3.15"
             type: fpm
           - php: "8.1"
             alpine: "3.15"
@@ -499,6 +511,12 @@ jobs:
             type: cli
           - php: "8.0"
             alpine: "3.14"
+            type: fpm
+          - php: "8.0"
+            alpine: "3.15"
+            type: cli
+          - php: "8.0"
+            alpine: "3.15"
             type: fpm
           - php: "8.1"
             alpine: "3.15"


### PR DESCRIPTION
Missed these in #183. But, it was a good example
that we can improve the matrix and centralize entries
in one place.


Reviewers: @usabilla/oss-docker
