### PR TITLE
Added configration for SurveyMonkey User Service API cache

### DIFF
--- a/Dockerfile-http
+++ b/Dockerfile-http
@@ -11,6 +11,9 @@ ARG NGINX_VHOST_TEMPLATE
 ENV NGINX_DOCUMENT_ROOT="/opt/project/public"
 ENV NGINX_SERVER_NAME=localhost
 ENV NGINX_PORT=80
+ENV NGINX_PERMISSIONS_CACHE_PORT=8081
+ENV NGINX_PERMISSIONS_CACHE_HOST="http://mt3-usersvc-vip.w8.jungle.tech"
+ENV NGINX_DNS_RESOLVER=10.228.0.35
 ENV NGINX_WORKERS_PROCESSES=1
 ENV NGINX_WORKERS_CONNECTIONS=1024
 ENV NGINX_KEEPALIVE_TIMEOUT=65
@@ -30,6 +33,8 @@ COPY src/http/nginx/docker-nginx-* /usr/local/bin/
 # Nginx configuration filesg 
 COPY src/http/nginx/conf/main /etc/nginx/
 COPY src/http/nginx/conf/${NGINX_VHOST_TEMPLATE} /etc/nginx/
+COPY src/http/nginx/conf/cache /etc/nginx/
+RUN mkdir -p ${NGINX_DOCUMENT_ROOT}/usersvccache
 
 CMD ["docker-nginx-entrypoint"]
 

--- a/src/http/nginx/conf/cache/perm.conf.template
+++ b/src/http/nginx/conf/cache/perm.conf.template
@@ -1,0 +1,43 @@
+server {
+    listen ${NGINX_PERMISSIONS_CACHE_PORT};
+    listen [::]:${NGINX_PERMISSIONS_CACHE_PORT};
+    server_name  ${NGINX_SERVER_NAME};
+
+    root    ${NGINX_DOCUMENT_ROOT};
+    charset UTF-8;
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # A directive that will run DNS resolution process for a domain name
+    resolver ${NGINX_DNS_RESOLVER} valid=60s;
+
+    location / {
+        # Cache key should be defined in HTTP section
+        proxy_cache usersvc;
+        
+        # We will lock cache and will aggressively use it once we have a valid record for at least 2 minutes
+        proxy_cache_min_uses 1;
+        proxy_cache_lock on;
+        proxy_cache_valid 200 2m;
+
+        # We will cache POST and GET requests
+        proxy_cache_methods POST GET;
+        proxy_buffering on;
+
+        # Our cache key will be URI + Body to support GET and POST methods
+        proxy_cache_key "${ESCAPE}request_uri|${ESCAPE}request_body";
+
+        # We won't duplicate Vary header
+        proxy_hide_header Vary;
+
+        # Propagate a header to the client for request tracking
+        add_header X-Cache-Status ${ESCAPE}upstream_cache_status always;
+        
+        # This is a trick to enable NGINX to use resolver directive, if it is set without set directive it will be resolved only on startup once
+        set ${ESCAPE}upstream ${NGINX_PERMISSIONS_CACHE_HOST};
+        proxy_pass ${ESCAPE}upstream;
+    }
+}

--- a/src/http/nginx/conf/main/nginx.conf.template
+++ b/src/http/nginx/conf/main/nginx.conf.template
@@ -13,12 +13,15 @@ http {
     include       /etc/nginx/mime.types;
     default_type  text/plain;
 
-    log_format custom  '${ESCAPE}remote_addr - ${ESCAPE}remote_user [${ESCAPE}time_local] "${ESCAPE}request" '
+    log_format custom  '${ESCAPE}request_time ${ESCAPE}remote_addr - ${ESCAPE}remote_user [${ESCAPE}time_local] "${ESCAPE}request" '
                        '${ESCAPE}status ${ESCAPE}body_bytes_sent '
                        '"${ESCAPE}http_referer" "${ESCAPE}http_user_agent" '
                        '"X-Forwarded-For: ${ESCAPE}http_x_forwarded_for" '
                        '"Accept: ${ESCAPE}http_accept" '
                        '"Accept-Encoding: ${ESCAPE}http_accept_encoding"';
+
+    # Define cache for 
+    proxy_cache_path ${NGINX_DOCUMENT_ROOT}/usersvccache levels=1:2 keys_zone=usersvc:10m inactive=24h  max_size=1g;
 
     access_log /dev/stdout custom;
     error_log stderr notice;

--- a/src/http/nginx/docker-nginx-entrypoint
+++ b/src/http/nginx/docker-nginx-entrypoint
@@ -3,6 +3,7 @@ set -e
 
 ## From the environment variables replace the nginx configuration placeholders
 ESCAPE='$' envsubst < /etc/nginx/vhost.conf.template > /etc/nginx/conf.d/default.conf
+ESCAPE='$' envsubst < /etc/nginx/perm.conf.template > /etc/nginx/conf.d/cache.perm.conf
 ESCAPE='$' envsubst < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 ESCAPE='$' envsubst < /etc/nginx/location.d-available/cors.conf.template > /etc/nginx/location.d-available/cors.conf
 


### PR DESCRIPTION
At the moment we are heavily relying on `/get_permissions` and `/role_and_permissions` API endpoints from User Service. We do a lot of authorization requests within one context view. Enabling caching would allow us to improve latency and reduce amount of requests to the upstream.

# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| yes
| Build feature?    | no
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

## Changelog

- Please make sure you have checked our [Contributing guidelines](https://github.com/usabilla/php-docker-template/blob/master/.github/CONTRIBUTING.md)