### PR TITLE
Build PHP 8.0 with Alpine 3.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,12 @@ jobs:
           - php: "8.0"
             alpine: "3.15"
             type: fpm
+          - php: "8.0"
+            alpine: "3.16"
+            type: cli
+          - php: "8.0"
+            alpine: "3.16"
+            type: fpm
           - php: "8.1"
             alpine: "3.15"
             type: cli
@@ -239,6 +245,12 @@ jobs:
             type: cli
           - php: "8.0"
             alpine: "3.15"
+            type: fpm
+          - php: "8.0"
+            alpine: "3.16"
+            type: cli
+          - php: "8.0"
+            alpine: "3.16"
             type: fpm
           - php: "8.1"
             alpine: "3.15"
@@ -355,6 +367,12 @@ jobs:
             type: cli
           - php: "8.0"
             alpine: "3.15"
+            type: fpm
+          - php: "8.0"
+            alpine: "3.16"
+            type: cli
+          - php: "8.0"
+            alpine: "3.16"
             type: fpm
           - php: "8.1"
             alpine: "3.15"
@@ -535,6 +553,12 @@ jobs:
             type: cli
           - php: "8.0"
             alpine: "3.15"
+            type: fpm
+          - php: "8.0"
+            alpine: "3.16"
+            type: cli
+          - php: "8.0"
+            alpine: "3.16"
             type: fpm
           - php: "8.1"
             alpine: "3.15"


### PR DESCRIPTION
# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| no
| Build feature?    | no
| Apply CVE Patch?  | yes
| Remove CVE Patch? | no

## Changelog

In order for us to receive the latest PHP update, 8.0.28, we need to build a more recent version of Alpine.

Note for future: we shall reduce the complexity of our pipeline by creating an array of supported PHP and Alpine versions, and have the jobs/stages using it.
