### PR TITLE
Build PHP 8.1 with Alpine 3.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,12 @@ jobs:
           - php: "8.1"
             alpine: "3.15"
             type: fpm
+          - php: "8.1"
+            alpine: "3.16"
+            type: cli
+          - php: "8.1"
+            alpine: "3.16"
+            type: fpm
           - php: "8.2"
             alpine: "3.17"
             type: "cli"
@@ -257,6 +263,12 @@ jobs:
             type: cli
           - php: "8.1"
             alpine: "3.15"
+            type: fpm
+          - php: "8.1"
+            alpine: "3.16"
+            type: cli
+          - php: "8.1"
+            alpine: "3.16"
             type: fpm
           - php: "8.2"
             alpine: "3.17"
@@ -379,6 +391,12 @@ jobs:
             type: cli
           - php: "8.1"
             alpine: "3.15"
+            type: fpm
+          - php: "8.1"
+            alpine: "3.16"
+            type: cli
+          - php: "8.1"
+            alpine: "3.16"
             type: fpm
           - php: "8.2"
             alpine: "3.17"
@@ -565,6 +583,12 @@ jobs:
             type: cli
           - php: "8.1"
             alpine: "3.15"
+            type: fpm
+          - php: "8.1"
+            alpine: "3.16"
+            type: cli
+          - php: "8.1"
+            alpine: "3.16"
             type: fpm
           - php: "8.2"
             alpine: "3.17"


### PR DESCRIPTION
# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| no
| Build feature?    | no
| Apply CVE Patch?  | yes
| Remove CVE Patch? | no

## Changelog

In order for us to receive the latest PHP update, 8.1.16, we need to build with more recent versions of Alpine.

Note for future: we shall reduce the complexity of our pipeline by creating an array of supported PHP and Alpine versions, and have the jobs/stages to use it.