### PR TITLE
Use curl-dev instead of curl

### DIFF
--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -15,6 +15,8 @@ COPY src/php/utils/docker/ /usr/local/bin/
 # Install PHP extensions
 # hadolint ignore=DL4006
 RUN set -x \
+    # Install curl-dev in order to address the curl binary issue in some Alpine versions
+    && apk add --no-cache curl-dev \
     # Adding sodium purely for the 7.1 image, it's already in 7.2 and up: https://www.php.net/manual/en/sodium.installation.php \
     && apk add --no-cache wget \
     && if [ $(php -v | grep "PHP 7.1" | wc -l) != 0 ] ; then apk add --no-cache libsodium-dev; else true; fi \

--- a/Dockerfile-fpm
+++ b/Dockerfile-fpm
@@ -26,6 +26,8 @@ COPY src/php/utils/install-* /usr/local/bin/
 # Install PHP extensions
 # hadolint ignore=DL4006
 RUN set -x \
+    # Install curl-dev in order to address the curl binary issue in some Alpine versions
+    && apk add --no-cache curl-dev \
     # Adding sodium purely for the 7.1 image, it's already in 7.2 and up: https://www.php.net/manual/en/sodium.installation.php \
     && apk add --no-cache wget gettext \
     && if [ $(php -v | grep "PHP 7.1" | wc -l) != 0 ] ; then apk add --no-cache libsodium-dev; else true; fi \


### PR DESCRIPTION
The purpose of the PR is to use `curl-dev` instead of `curl` because the latter triggers problems during the build of images for certain Alpine versions.

Fixes [AN-4376](https://surveymonkey.atlassian.net/jira/software/c/projects/AN/boards/2820/backlog?selectedIssue=AN-4376)