### PR TITLE
Add php 8.3 with Alpine 3.20 + GHA dependency upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - run: docker save "${DOCKER_IMAGE}" | gzip -9 > ./tmp/image-http-${{ matrix.nginx }}.tar
         shell: bash
       - name: Upload Images
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docker-image-http-${{ matrix.nginx }}
           path: ./tmp
@@ -142,7 +142,7 @@ jobs:
       - run: docker save "${DOCKER_IMAGE}" | gzip -9 > ./tmp/image-prometheus-exporter-file.tar
         shell: bash
       - name: Upload Images
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docker-image-prometheus-exporter-file
           path: ./tmp
@@ -231,7 +231,7 @@ jobs:
       - run: docker save "${DOCKER_IMAGE}" | gzip -9 > ./tmp/image-${{ matrix.type }}-${{ matrix.php }}-${{ matrix.alpine }}.tar
         shell: bash
       - name: Upload Images
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docker-image-${{ matrix.type }}-${{ matrix.php }}-${{ matrix.alpine }}
           path: ./tmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,12 @@ jobs:
           - php: "8.3"
             alpine: "3.19"
             type: "fpm"
+          - php: "8.3"
+            alpine: "3.20"
+            type: "fpm"
+          - php: "8.3"
+            alpine: "3.20"
+            type: "cli"
     steps:
       - uses: actions/checkout@v2
       - run: ./build-php.sh ${{ matrix.type }} ${{ matrix.php }} ${{ matrix.alpine }}
@@ -312,6 +318,12 @@ jobs:
           - php: "8.3"
             alpine: "3.19"
             type: "fpm"
+          - php: "8.3"
+            alpine: "3.20"
+            type: "fpm"
+          - php: "8.3"
+            alpine: "3.20"
+            type: "cli"
     steps:
       - uses: actions/checkout@v2
       - name: Install clair-scanner
@@ -458,6 +470,12 @@ jobs:
           - php: "8.3"
             alpine: "3.19"
             type: "fpm"
+          - php: "8.3"
+            alpine: "3.20"
+            type: "fpm"
+          - php: "8.3"
+            alpine: "3.20"
+            type: "cli"
     steps:
       - uses: actions/checkout@v2
       - name: Download Images
@@ -668,6 +686,12 @@ jobs:
           - php: "8.3"
             alpine: "3.19"
             type: "fpm"
+          - php: "8.3"
+            alpine: "3.20"
+            type: "fpm"
+          - php: "8.3"
+            alpine: "3.20"
+            type: "cli"
     steps:
       - uses: actions/checkout@v2
       - name: Download Images

--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,8 @@ test-prometheus-exporter-file-e2e: ./tmp/build-prometheus-exporter-file.tags
 	xargs -I % ./test-prometheus-exporter-file-e2e.sh % < ./tmp/build-prometheus-exporter-file.tags
 
 scan-vulnerability:
-	docker-compose -f test/security/docker-compose.yml -p clair-ci up -d
+	docker compose -f test/security/docker-compose.yml -p clair-ci up -d
 	RETRIES=0 && while ! wget -T 10 -q -O /dev/null http://localhost:6060/v1/namespaces ; do sleep 1 ; echo -n "." ; if [ $${RETRIES} -eq 10 ] ; then echo " Timeout, aborting." ; exit 1 ; fi ; RETRIES=$$(($${RETRIES}+1)) ; done
 	mkdir -p ./tmp/clair/usabillabv
 	cat ./tmp/build-*.tags | xargs -I % sh -c 'clair-scanner --ip 172.17.0.1 -r "./tmp/clair/%.json" -l ./tmp/clair/clair.log % || echo "% is vulnerable"'
-	docker-compose -f test/security/docker-compose.yml -p clair-ci down
+	docker compose -f test/security/docker-compose.yml -p clair-ci down

--- a/test/container/php/test_helper_scripts.py
+++ b/test/container/php/test_helper_scripts.py
@@ -11,9 +11,11 @@ def test_php_images_contain_helper_scripts(host):
     ]
 
     for file in official_helper_scripts:
+        expected_file_mode = get_expected_os_mode(host)
+
         assert host.file(file).exists is True
         assert host.file(file).is_file is True
-        assert host.file(file).mode == 0o775
+        assert host.file(file).mode == expected_file_mode
 
     helper_scripts = [
         "/usr/local/bin/docker-php-dev-mode",
@@ -74,3 +76,15 @@ def test_php_extension_script_for_rdkafka(host):
 def test_php_extension_script_for_pdo_pgsql(host):
     host.run_expect([0], "docker-php-ext-pdo-pgsql")
     assert 'pdo_pgsql' in host.run('php -m').stdout
+
+def get_os_version(host):
+    return host.run("cat /etc/alpine-release").stdout
+
+def get_expected_os_mode(host):
+    expected_file_mode = 0o775
+    os_version = get_os_version(host)
+
+    if os_version > "3.17.999":
+        expected_file_mode = 0o755
+
+    return expected_file_mode


### PR DESCRIPTION
# Usabilla PHP Docker Template

- It add php 8.3 on alpine 3.20 as part of the build pipeline
- upgrades actions/upload-artifact to v4
- replaces the legacy docker compose syntax
- adjusts one assertion related to php helper script tests

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| no
| Build feature?    | yes
| Apply CVE Patch?  | no
| Remove CVE Patch? | no

## Changelog

- Please make sure you have checked our [Contributing guidelines](https://github.com/usabilla/php-docker-template/blob/master/.github/CONTRIBUTING.md)
