### PR TITLE
Restore temporary disabled matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
         name: Generate Alpine
         shell: bash
         run: |
-          echo "versions=[\"3.21\"]" >> $GITHUB_OUTPUT
-#          echo "versions=[\"3.22\",\"3.21\",\"3.19\"]" >> $GITHUB_OUTPUT
+          echo "versions=[\"3.22\",\"3.21\",\"3.19\"]" >> $GITHUB_OUTPUT
   supported-nginx-versions:
     name: Supported nginx versions
     runs-on: ubuntu-latest
@@ -54,8 +53,7 @@ jobs:
         name: Generate PHP
         shell: bash
         run: |
-          echo "versions=[\"8.3\"]" >> $GITHUB_OUTPUT
-#          echo "versions=[\"8.4\",\"8.3\",\"8.2\"]" >> $GITHUB_OUTPUT
+          echo "versions=[\"8.4\",\"8.3\",\"8.2\"]" >> $GITHUB_OUTPUT
   php-type-matrix:
     name: PHP Type Matrix
     runs-on: ubuntu-latest


### PR DESCRIPTION
During the last validation of #204 I disabled most of the matrix to validate the full workflow with an as small as possible matrix. While setting it back up ready for merging I forgot to restore the temporary disabled matrix parts.

# Usabilla PHP Docker Template

Reviewers: @usabilla/oss-docker

## Type

Please specify the type of changes being proposed:

| Q                 | A
| ----------------- | -----
| Documentation?    | no
| Dockerfile change?| no
| Build feature?    | yes
| Apply CVE Patch?  | no
| Remove CVE Patch? | no
